### PR TITLE
find_elements -> find_element in Python code generation

### DIFF
--- a/Appium/Inspector/Recorder/CodeMaker/Plugins/AppiumCodeMakerPythonPlugin.m
+++ b/Appium/Inspector/Recorder/CodeMaker/Plugins/AppiumCodeMakerPythonPlugin.m
@@ -172,9 +172,9 @@ try:\n", self.model.appPath, self.model.ipAddress, self.model.port];
 	switch(newLocator.locatorType)
 	{
 		case APPIUM_CODE_MAKER_LOCATOR_TYPE_NAME:
-			return [NSString stringWithFormat:@"wd.find_elements_by_name(\"%@\")", [self escapeString:newLocator.locatorString]];
+			return [NSString stringWithFormat:@"wd.find_element_by_name(\"%@\")", [self escapeString:newLocator.locatorString]];
 		case APPIUM_CODE_MAKER_LOCATOR_TYPE_XPATH:
-			return [NSString stringWithFormat:@"wd.find_elements_by_xpath(\"%@\")", [self escapeString:newLocator.locatorString]];
+			return [NSString stringWithFormat:@"wd.find_element_by_xpath(\"%@\")", [self escapeString:newLocator.locatorString]];
 		default: return nil;
 	}
 }


### PR DESCRIPTION
Otherwise things just... don't work at all. The rest of the code generation assumes a single element being produced from this generated code. All the other languages use their equivalent find-one function to suit this requirement, so not sure how Python got left out.
