### PR TITLE
Fixed #224 (Failure to launch If app name has a quote in it)

### DIFF
--- a/Appium/Server/Model/AppiumModel.m
+++ b/Appium/Server/Model/AppiumModel.m
@@ -412,14 +412,7 @@ BOOL _isServerListening;
     }
     if (self.useAppPath)
     {
-		if ([self.appPath hasSuffix:@"ipa"])
-		{
-			nodeCommandString = [nodeCommandString stringByAppendingFormat:@" %@ %@", @"--ipa", [self.appPath stringByReplacingOccurrencesOfString:@" " withString:@"\\ "]];
-		}
-		else
-		{
-			nodeCommandString = [nodeCommandString stringByAppendingFormat:@" %@ %@", @"--app", [self.appPath stringByReplacingOccurrencesOfString:@" " withString:@"\\ "]];
-		}
+        nodeCommandString = [nodeCommandString stringByAppendingFormat:@" %@ \"%@\"", ([self.appPath hasSuffix:@"ipa"]) ? @"--ipa" : @"--app", self.appPath];
     }
 	else if (self.useBundleID)
     {


### PR DESCRIPTION
Path is now in quotes instead of replacing spaces.

Also added a switch statement instead of using an if statement.
