### PR TITLE
Add setting to project to default tabs instead of spaces

### DIFF
--- a/Appium.xcodeproj/project.pbxproj
+++ b/Appium.xcodeproj/project.pbxproj
@@ -656,6 +656,7 @@
 				36CEB7C916E3662E00B5B100 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		36CEB7C916E3662E00B5B100 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
By default Xcode uses spaces instead of tabs. This sets the preference at a project level so that this is observed even if this is not set in the Xcode preferences.
