### PR TITLE
Fix #300 (Provide scroll lock in logging window)

### DIFF
--- a/Appium/AppleScript/appium.sdef
+++ b/Appium/AppleScript/appium.sdef
@@ -242,6 +242,9 @@
 			<property name="log webhook" code="gs08" type="text">
 				<cocoa key="logWebHook"/>
 			</property>
+			<property name="force scroll log" code="gs09" type="boolean">
+				<cocoa key="forceScrollLog"/>
+			</property>
 			<property name="override existing sessions" code="gs09" type="boolean">
 				<cocoa key="overrideExistingSessions"/>
 			</property>

--- a/Appium/Server/Model/AppiumGeneralSettingsModel.h
+++ b/Appium/Server/Model/AppiumGeneralSettingsModel.h
@@ -17,6 +17,7 @@
 @property NSString *logFile;
 @property BOOL logTimestamps;
 @property NSString *logWebHook;
+@property BOOL forceScrollLog;
 @property BOOL overrideExistingSessions;
 @property BOOL prelaunchApp;
 @property NSString *seleniumGridConfigFile;

--- a/Appium/Server/Model/AppiumGeneralSettingsModel.m
+++ b/Appium/Server/Model/AppiumGeneralSettingsModel.m
@@ -47,6 +47,9 @@
 -(NSString*) logWebHook { return [DEFAULTS stringForKey:APPIUM_PLIST_LOG_WEBHOOK]; }
 -(void) setLogWebHook:(NSString *)logWebHook { [DEFAULTS setValue:logWebHook forKey:APPIUM_PLIST_LOG_WEBHOOK]; }
 
+-(BOOL) forceScrollLog { return [DEFAULTS boolForKey:APPIUM_PLIST_LOG_FORCE_SCROLL]; }
+-(void) setForceScrollLog:(BOOL)forceScrollLog { [DEFAULTS setBool:forceScrollLog forKey:APPIUM_PLIST_LOG_FORCE_SCROLL]; }
+
 -(BOOL) overrideExistingSessions { return [DEFAULTS boolForKey:APPIUM_PLIST_OVERRIDE_EXISTING_SESSIONS]; }
 -(void) setOverrideExistingSessions:(BOOL)overrideExistingSessions { [DEFAULTS setBool:overrideExistingSessions forKey:APPIUM_PLIST_OVERRIDE_EXISTING_SESSIONS]; }
 

--- a/Appium/Server/Monitor/AppiumMonitorWindowController.m
+++ b/Appium/Server/Monitor/AppiumMonitorWindowController.m
@@ -101,14 +101,23 @@
 
 -(void) appendToLog:(NSAttributedString*)string
 {
-	// Check if the scroll position is within 30 pixels of the bottom of the view
-	BOOL scrolledToBottom = (((self.logTextView.visibleRect.origin.y + self.logTextView.superview.frame.size.height) - self.logTextView.bounds.size.height) >= -30.0f);
+	BOOL scrollToBottom;
+	
+	if (!self.model.general.forceScrollLog)
+	{
+		// Check if the scroll position is within 30 pixels of the bottom of the view
+		scrollToBottom = (((self.logTextView.visibleRect.origin.y + self.logTextView.superview.frame.size.height) - self.logTextView.bounds.size.height) >= -30.0f);
+	}
+	else
+	{
+		scrollToBottom = YES;
+	}
 	
     [[self.logTextView textStorage] beginEditing];
     [[self.logTextView textStorage] appendAttributedString:string];
     [[self.logTextView textStorage] endEditing];
 	
-	if (scrolledToBottom)
+	if (scrollToBottom)
 	{
 		NSRange range = NSMakeRange ([[self.logTextView string] length], 0);
 	

--- a/Appium/Server/Preferences/AppiumPreferencesFile.h
+++ b/Appium/Server/Preferences/AppiumPreferencesFile.h
@@ -88,6 +88,7 @@
 #define APPIUM_PLIST_LOG_FILE @"Log File"
 #define APPIUM_PLIST_LOG_TIMESTAMPS @"Log Timestamps"
 #define APPIUM_PLIST_LOG_WEBHOOK @"Log Webhook"
+#define APPIUM_PLIST_LOG_FORCE_SCROLL @"Force Scroll Log"
 #define APPIUM_PLIST_NEW_COMMAND_TIMEOUT @"New Command Timeout"
 #define APPIUM_PLIST_NODEJS_DEBUG_PORT @"NodeJS Debug Port"
 #define APPIUM_PLIST_OVERRIDE_EXISTING_SESSIONS @"Override Existing Sessions"

--- a/Appium/XIBs/AppiumMonitorWindow.xib
+++ b/Appium/XIBs/AppiumMonitorWindow.xib
@@ -2683,11 +2683,11 @@
             <accessibility description="iOSSettingsView"/>
         </customView>
         <customView id="lfV-Jy-qRr" userLabel="General Settings View">
-            <rect key="frame" x="0.0" y="0.0" width="417" height="426"/>
+            <rect key="frame" x="0.0" y="0.0" width="417" height="448"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="pFP-rp-D7j" userLabel="General Settings Label">
-                    <rect key="frame" x="17" y="389" width="107" height="17"/>
+                    <rect key="frame" x="17" y="411" width="107" height="17"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="General Settings" id="Svf-QT-oNe">
                         <font key="font" metaFont="system"/>
@@ -2696,7 +2696,7 @@
                     </textFieldCell>
                 </textField>
                 <box autoresizesSubviews="NO" title="Server" borderType="line" id="ATX-v7-2MS" userLabel="Selenium Grid Configuration Box">
-                    <rect key="frame" x="17" y="131" width="383" height="250"/>
+                    <rect key="frame" x="17" y="153" width="383" height="250"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <view key="contentView">
                         <rect key="frame" x="1" y="1" width="381" height="234"/>
@@ -3008,14 +3008,14 @@
                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                 </box>
                 <box autoresizesSubviews="NO" title="Logging" borderType="line" id="6DB-Rn-YeW" userLabel="Logging Box">
-                    <rect key="frame" x="17" y="16" width="383" height="111"/>
+                    <rect key="frame" x="17" y="16" width="383" height="133"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <view key="contentView">
-                        <rect key="frame" x="1" y="1" width="381" height="95"/>
+                        <rect key="frame" x="1" y="1" width="381" height="117"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button id="Sjw-Vh-exR" userLabel="Quiet Logging Check Box">
-                                <rect key="frame" x="16" y="69" width="112" height="18"/>
+                                <rect key="frame" x="16" y="91" width="112" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Quiet Logging" bezelStyle="regularSquare" imagePosition="left" inset="2" id="RAd-Rt-odx">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -3040,7 +3040,7 @@
                                 </connections>
                             </button>
                             <button id="lts-Bk-ASi" userLabel="Use Colors Check Box">
-                                <rect key="frame" x="134" y="69" width="90" height="18"/>
+                                <rect key="frame" x="134" y="91" width="90" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Use Colors" bezelStyle="regularSquare" imagePosition="left" inset="2" id="jex-eo-F4f">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -3065,7 +3065,7 @@
                                 </connections>
                             </button>
                             <button id="Yo3-kt-WeH" userLabel="Show Timestamps Check Box">
-                                <rect key="frame" x="232" y="69" width="137" height="18"/>
+                                <rect key="frame" x="232" y="91" width="137" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Show Timestamps" bezelStyle="regularSquare" imagePosition="left" inset="2" id="zVv-Va-qaG">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -3090,7 +3090,7 @@
                                 </connections>
                             </button>
                             <button id="XYh-qS-VqU" userLabel="Log To File Check Box">
-                                <rect key="frame" x="16" y="43" width="92" height="18"/>
+                                <rect key="frame" x="16" y="65" width="92" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Log To File" bezelStyle="regularSquare" imagePosition="left" inset="2" id="KAP-K2-Kna">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -3115,7 +3115,7 @@
                                 </connections>
                             </button>
                             <textField verticalHuggingPriority="750" id="Ith-xg-9Ja" userLabel="Log File Path Text Field">
-                                <rect key="frame" x="117" y="41" width="250" height="22"/>
+                                <rect key="frame" x="117" y="63" width="250" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="KsP-C6-4eY">
                                     <font key="font" metaFont="system"/>
@@ -3146,7 +3146,7 @@
                                 </connections>
                             </textField>
                             <button id="7Dd-2o-uFC" userLabel="Log To Webhook Check Box">
-                                <rect key="frame" x="16" y="16" width="146" height="18"/>
+                                <rect key="frame" x="16" y="38" width="146" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Log To WebHook" bezelStyle="regularSquare" imagePosition="left" inset="2" id="G7m-AP-E4e">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -3171,7 +3171,7 @@
                                 </connections>
                             </button>
                             <textField verticalHuggingPriority="750" id="HRq-2J-jb3" userLabel="Webhook Address Text Field">
-                                <rect key="frame" x="158" y="14" width="209" height="22"/>
+                                <rect key="frame" x="158" y="36" width="209" height="22"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="cfD-hT-Kyz">
                                     <font key="font" metaFont="system"/>
@@ -3201,6 +3201,17 @@
                                     </binding>
                                 </connections>
                             </textField>
+                            <button id="5Ae-M5-oVP" userLabel="Force Scroll Log to Bottom Check Box">
+                                <rect key="frame" x="16" y="12" width="349" height="18"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="check" title="Force Scroll Log to Bottom" bezelStyle="regularSquare" imagePosition="left" inset="2" id="YYU-jz-9TJ">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <binding destination="-2" name="value" keyPath="model.general.forceScrollLog" id="VWQ-o3-FJ4"/>
+                                </connections>
+                            </button>
                         </subviews>
                     </view>
                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>


### PR DESCRIPTION
Being scrolled to the bottom of the log is measured within 30 pixels, which is roughly a single line.

There is also an option (disabled by default) to force the log to scroll to the bottom regardless of where it is scrolled to, as it previously behaved.
