### PR TITLE
Fix #292 (Appium client shows older capabilities values)

### DIFF
--- a/Appium/Inspector/Recorder/CodeMaker/Plugins/AppiumCodeMakerCSharpPlugin.m
+++ b/Appium/Inspector/Recorder/CodeMaker/Plugins/AppiumCodeMakerCSharpPlugin.m
@@ -20,10 +20,10 @@
 -(id) initWithCodeMaker:(AppiumCodeMaker*)codeMaker
 {
 	self = [super init];
-    if (self) {
-        [self setCodeMaker:codeMaker];
-    }
-    return self;
+	if (self) {
+		[self setCodeMaker:codeMaker];
+	}
+	return self;
 }
 
 #pragma mark - AppiumCodeMakerPlugin Implementation
@@ -105,7 +105,7 @@ namespace AppiumTests {\n\
 
 -(NSString*) postCodeBoilerplate
 {
-    return
+	return
 @"\t\t\t} finally { wd.Quit(); }\n\
 \t\t}\n\
 \n\
@@ -142,13 +142,13 @@ namespace AppiumTests {\n\
 
 -(NSString*) executeScript:(AppiumCodeMakerActionExecuteScript*)action
 {
-    return [NSString stringWithFormat:@"%@wd.ExecuteScript(\"%@\", null);\n", self.indentation, [self escapeString:action.script]];
+	return [NSString stringWithFormat:@"%@wd.ExecuteScript(\"%@\", null);\n", self.indentation, [self escapeString:action.script]];
 }
 
 -(NSString*) preciseTap:(AppiumCodeMakerActionPreciseTap*)action
 {
-    NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
-    return [NSString stringWithFormat:@"wd.ExecuteScript(\"mobile: tap\", \
+	NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
+	return [NSString stringWithFormat:@"wd.ExecuteScript(\"mobile: tap\", \
 new Dictionary<string, double>() \
 { \
 { \"tapCount\", %@ }, \
@@ -166,8 +166,8 @@ new Dictionary<string, double>() \
 
 -(NSString*) swipe:(AppiumCodeMakerActionSwipe*)action
 {
-    NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
-    return [NSString stringWithFormat:@"wd.ExecuteScript(\"mobile: swipe\", \
+	NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
+	return [NSString stringWithFormat:@"wd.ExecuteScript(\"mobile: swipe\", \
 new Dictionary<string, double>() \
 { \
 { \"touchCount\", %@ }, \
@@ -181,7 +181,7 @@ new Dictionary<string, double>() \
 
 -(NSString*) shake:(AppiumCodeMakerActionShake*)action
 {
-    return [NSString stringWithFormat:@"%@wd.ExecuteScript(\"mobile: shake\", null);\n", self.indentation];
+	return [NSString stringWithFormat:@"%@wd.ExecuteScript(\"mobile: shake\", null);\n", self.indentation];
 }
 
 -(NSString*) tap:(AppiumCodeMakerActionTap*)action
@@ -192,7 +192,7 @@ new Dictionary<string, double>() \
 #pragma mark - Helper Methods
 -(NSString*) escapeString:(NSString *)string
 {
-    return [string stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
+	return [string stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
 }
 
 -(NSString*) indentation { return [self.codeMaker.useBoilerPlate boolValue] ? @"\t\t\t\t" : @""; }

--- a/Appium/Inspector/Recorder/CodeMaker/Plugins/AppiumCodeMakerJavaPlugin.m
+++ b/Appium/Inspector/Recorder/CodeMaker/Plugins/AppiumCodeMakerJavaPlugin.m
@@ -20,10 +20,10 @@
 -(id) initWithCodeMaker:(AppiumCodeMaker*)codeMaker
 {
 	self = [super init];
-    if (self) {
-        [self setCodeMaker:codeMaker];
-    }
-    return self;
+	if (self) {
+		[self setCodeMaker:codeMaker];
+	}
+	return self;
 }
 
 
@@ -100,7 +100,7 @@ public class {scriptName} {\n\
 
 -(NSString*) postCodeBoilerplate
 {
-    return
+	return
 @"\t\twd.close();\n\
 \t}\n\
 }\n";
@@ -128,13 +128,13 @@ public class {scriptName} {\n\
 
 -(NSString*) executeScript:(AppiumCodeMakerActionExecuteScript*)action
 {
-    return [NSString stringWithFormat:@"%@(JavascriptExecutor)wd.executeScript(\"%@\", null);\n", self.indentation, [self escapeString:action.script]];
+	return [NSString stringWithFormat:@"%@(JavascriptExecutor)wd.executeScript(\"%@\", null);\n", self.indentation, [self escapeString:action.script]];
 }
 
 -(NSString*) preciseTap:(AppiumCodeMakerActionPreciseTap*)action
 {
-    NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
-    return [NSString stringWithFormat:@"(JavascriptExecutor)wd.executeScript(\"mobile: tap\", \
+	NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
+	return [NSString stringWithFormat:@"(JavascriptExecutor)wd.executeScript(\"mobile: tap\", \
 new HashMap<String, Double>() \
 {{ \
 put(\"tapCount\", %@); \
@@ -152,13 +152,13 @@ put(\"y\", %@); \
 
 -(NSString*) shake:(AppiumCodeMakerActionShake*)action
 {
-    return [NSString stringWithFormat:@"%@(JavascriptExecutor)wd.executeScript(\"mobile: shake\", null);\n", self.indentation];
+	return [NSString stringWithFormat:@"%@(JavascriptExecutor)wd.executeScript(\"mobile: shake\", null);\n", self.indentation];
 }
 
 -(NSString*) swipe:(AppiumCodeMakerActionSwipe*)action
 {
-    NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
-    return [NSString stringWithFormat:@"(JavascriptExecutor)wd.executeScript(\"mobile: swipe\", \
+	NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
+	return [NSString stringWithFormat:@"(JavascriptExecutor)wd.executeScript(\"mobile: swipe\", \
 new HashMap<String, Double>() \
 {{ \
 put(\"touchCount\", %@); \
@@ -178,7 +178,7 @@ put(\"duration\", %@); \
 #pragma mark - Helper Methods
 -(NSString*) escapeString:(NSString *)string
 {
-    return [string stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
+	return [string stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
 }
 
 -(NSString*) indentation { return [self.codeMaker.useBoilerPlate boolValue] ? @"\t\t" : @""; }

--- a/Appium/Inspector/Recorder/CodeMaker/Plugins/AppiumCodeMakerObjectiveCPlugin.m
+++ b/Appium/Inspector/Recorder/CodeMaker/Plugins/AppiumCodeMakerObjectiveCPlugin.m
@@ -20,10 +20,10 @@
 -(id) initWithCodeMaker:(AppiumCodeMaker*)codeMaker
 {
 	self = [super init];
-    if (self) {
-        [self setCodeMaker:codeMaker];
-    }
-    return self;
+	if (self) {
+		[self setCodeMaker:codeMaker];
+	}
+	return self;
 }
 
 #pragma mark - AppiumCodeMakerPlugin Implementation
@@ -99,7 +99,7 @@
 
 -(NSString*) postCodeBoilerplate
 {
-    return
+	return
 @"}\n\
 \n\
 @end\n";
@@ -127,13 +127,13 @@
 
 -(NSString*) executeScript:(AppiumCodeMakerActionExecuteScript*)action
 {
-    return [NSString stringWithFormat:@"%@[wd executeScript:@\"%@\"];\n", self.indentation, [self escapeString:action.script]];
+	return [NSString stringWithFormat:@"%@[wd executeScript:@\"%@\"];\n", self.indentation, [self escapeString:action.script]];
 }
 
 -(NSString*) preciseTap:(AppiumCodeMakerActionPreciseTap*)action
 {
-    NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
-    return [NSString stringWithFormat:@"\[wd executeScript:@\"mobile: tap\" arguments:\
+	NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
+	return [NSString stringWithFormat:@"\[wd executeScript:@\"mobile: tap\" arguments:\
 [[NSArray alloc] initWithObjects:[[NSDictionary alloc] initWithObjectsAndKeys:\
 [NSNumber numberWithInteger:%@, @\"tapCount\", \
 [NSNumber numberWithInteger:%@, @\"touchCount\", \
@@ -150,13 +150,13 @@ nil], nil]];\n", [args objectForKey:@"tapCount"], [args objectForKey:@"touchCoun
 
 -(NSString*) shake:(AppiumCodeMakerActionShake*)action
 {
-    return [NSString stringWithFormat:@"%@[wd executeScript:@\"mobile: shake\"];\n", self.indentation];
+	return [NSString stringWithFormat:@"%@[wd executeScript:@\"mobile: shake\"];\n", self.indentation];
 }
 
 -(NSString*) swipe:(AppiumCodeMakerActionSwipe*)action
 {
-    NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
-    return [NSString stringWithFormat:@"\[wd executeScript:@\"mobile: swipe\" arguments:\
+	NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
+	return [NSString stringWithFormat:@"\[wd executeScript:@\"mobile: swipe\" arguments:\
 [[NSArray alloc] initWithObjects:[[NSDictionary alloc] initWithObjectsAndKeys:\
 [NSNumber numberWithInteger:%@, @\"touchCount\", \
 [NSNumber numberWithFloat:%@f, @\"startX\", \
@@ -175,7 +175,7 @@ nil], nil]];\n", [args objectForKey:@"touchCount"], [args objectForKey:@"startX"
 #pragma mark - Helper Methods
 -(NSString*) escapeString:(NSString *)string
 {
-    return [string stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
+	return [string stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
 }
 
 -(NSString*) indentation { return [self.codeMaker.useBoilerPlate boolValue] ? @"\t" : @""; }

--- a/Appium/Inspector/Recorder/CodeMaker/Plugins/AppiumCodeMakerPythonPlugin.m
+++ b/Appium/Inspector/Recorder/CodeMaker/Plugins/AppiumCodeMakerPythonPlugin.m
@@ -20,10 +20,10 @@
 -(id) initWithCodeMaker:(AppiumCodeMaker*)codeMaker
 {
 	self = [super init];
-    if (self) {
-        [self setCodeMaker:codeMaker];
-    }
-    return self;
+	if (self) {
+		[self setCodeMaker:codeMaker];
+	}
+	return self;
 }
 
 #pragma mark - AppiumCodeMakerPlugin Implementation
@@ -117,7 +117,7 @@ try:\n", self.model.general.serverAddress, self.model.general.serverPort];
 
 -(NSString*) postCodeBoilerplate
 {
-    return
+	return
 @"finally:\n\
 \twd.quit()\n\
 \tif not success:\n\
@@ -146,13 +146,13 @@ try:\n", self.model.general.serverAddress, self.model.general.serverPort];
 
 -(NSString*) executeScript:(AppiumCodeMakerActionExecuteScript*)action
 {
-    return [NSString stringWithFormat:@"%@wd.execute_script(\"%@\", None);\n", self.indentation, [self escapeString:action.script]];
+	return [NSString stringWithFormat:@"%@wd.execute_script(\"%@\", None);\n", self.indentation, [self escapeString:action.script]];
 }
 
 -(NSString*) preciseTap:(AppiumCodeMakerActionPreciseTap*)action
 {
-    NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
-    return [NSString stringWithFormat:@"wd.execute_script(\"mobile: tap\", {\
+	NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
+	return [NSString stringWithFormat:@"wd.execute_script(\"mobile: tap\", {\
 \"tapCount\": %@, \
 \"touchCount\": %@, \
 \"duration\": %@, \
@@ -168,13 +168,13 @@ try:\n", self.model.general.serverAddress, self.model.general.serverPort];
 
 -(NSString*) shake:(AppiumCodeMakerActionShake*)action
 {
-    return [NSString stringWithFormat:@"%@wd.execute_script(\"mobile: shake\", None);\n", self.indentation];
+	return [NSString stringWithFormat:@"%@wd.execute_script(\"mobile: shake\", None);\n", self.indentation];
 }
 
 -(NSString*) swipe:(AppiumCodeMakerActionSwipe*)action
 {
-    NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
-    return [NSString stringWithFormat:@"wd.execute_script(\"mobile: swipe\", {\
+	NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
+	return [NSString stringWithFormat:@"wd.execute_script(\"mobile: swipe\", {\
 \"touchCount\": %@ , \
 \"startX\": %@, \
 \"startY\": %@, \
@@ -192,7 +192,7 @@ try:\n", self.model.general.serverAddress, self.model.general.serverPort];
 #pragma mark - Helper Methods
 -(NSString*) escapeString:(NSString *)string
 {
-    return [string stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
+	return [string stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
 }
 
 -(NSString*) indentation { return [self.codeMaker.useBoilerPlate boolValue] ? @"\t" : @""; }

--- a/Appium/Inspector/Recorder/CodeMaker/Plugins/AppiumCodeMakerRubyPlugin.m
+++ b/Appium/Inspector/Recorder/CodeMaker/Plugins/AppiumCodeMakerRubyPlugin.m
@@ -14,10 +14,10 @@
 -(id) initWithCodeMaker:(AppiumCodeMaker*)codeMaker
 {
 	self = [super init];
-    if (self) {
-        [self setCodeMaker:codeMaker];
-    }
-    return self;
+	if (self) {
+		[self setCodeMaker:codeMaker];
+	}
+	return self;
 }
 
 #pragma mark - AppiumCodeMakerPlugin Implementation
@@ -97,7 +97,7 @@ Appium.promote_appium_methods Object\n\
 
 -(NSString*) postCodeBoilerplate
 {
-    return @"driver_quit\n";
+	return @"driver_quit\n";
 }
 
 -(NSString*) acceptAlert
@@ -122,19 +122,19 @@ Appium.promote_appium_methods Object\n\
 
 -(NSString*) executeScript:(AppiumCodeMakerActionExecuteScript*)action
 {
-    return [NSString stringWithFormat:@"execute_script \"%@\"\n", [self escapeString:action.script]];
+	return [NSString stringWithFormat:@"execute_script \"%@\"\n", [self escapeString:action.script]];
 }
 
 -(NSString*) preciseTap:(AppiumCodeMakerActionPreciseTap*)action
 {
-    NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
-    return [NSString stringWithFormat:@"Appium::TouchAction.new \
+	NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
+	return [NSString stringWithFormat:@"Appium::TouchAction.new \
 :x => %@, \
 :y => %@, \
 :fingers => %@, \
 :tapCount => %@, \
 :duration => %@\n",
-            [args objectForKey:@"x"], [args objectForKey:@"y"], [args objectForKey:@"touchCount"],
+			[args objectForKey:@"x"], [args objectForKey:@"y"], [args objectForKey:@"touchCount"],
 				[args objectForKey:@"tapCount"], [args objectForKey:@"duration"]];
 }
 
@@ -145,20 +145,20 @@ Appium.promote_appium_methods Object\n\
 
 -(NSString*) shake:(AppiumCodeMakerActionShake*)action
 {
-    return [NSString stringWithFormat:@"shake\n"];
+	return [NSString stringWithFormat:@"shake\n"];
 }
 
 -(NSString*) swipe:(AppiumCodeMakerActionSwipe*)action
 {
-    NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
-    return [NSString stringWithFormat:@"swipe \
+	NSDictionary *args = [((NSArray*)[action.params objectForKey:@"args"]) objectAtIndex:0];
+	return [NSString stringWithFormat:@"swipe \
 :start_x => %@, \
 :start_x => %@, \
 :end_x => %@, \
 :end_y => %@, \
 :touchCount => %@, \
 :duration => %@\n",
-            [args objectForKey:@"startX"], [args objectForKey:@"startY"], [args objectForKey:@"endX"],
+			[args objectForKey:@"startX"], [args objectForKey:@"startY"], [args objectForKey:@"endX"],
 				[args objectForKey:@"endY"], [args objectForKey:@"touchCount"], [args objectForKey:@"duration"]];
 }
 
@@ -170,7 +170,7 @@ Appium.promote_appium_methods Object\n\
 #pragma mark - Helper Methods
 -(NSString*) escapeString:(NSString *)string
 {
-    return [string stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
+	return [string stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
 }
 
 -(NSString*) locatorString:(AppiumCodeMakerLocator*)locator


### PR DESCRIPTION
Before merging, please could you check over these changes and ensure that everything required is sent correctly.

Both send:
- `appium-version`: `1.0`
- `platformName`: `self.model.android.platformVersion` or `iOS`
- `platformVersion`: `self.model.android.platformVersionNumber` or `self.model.iOS.platformVersion`
- `deviceName`: `self.model.android.deviceName` or `self.model.iOS.deviceName`
- `app`: `self.model.android.appPath` or `self.model.iOS.appPath`

In addition, Android sends:
- `appPackage`: `self.model.android.package`
- `appActivity`: `self.model.android.activity`

Also, I removed some imports on the Java file that didn't seem to be used. Please could you double check that this still looks ok (I don't have any Java complier installed)?
