### PR TITLE
Update default values for iOS 8.0 and 8.1

### DIFF
--- a/Appium/Server/Model/AppiumiOSSettingsModel.m
+++ b/Appium/Server/Model/AppiumiOSSettingsModel.m
@@ -55,7 +55,7 @@
 }
 
 -(NSArray*) allPlatformVersions {
-	return [NSArray arrayWithObjects:@"7.1.1", @"7.1", @"7.0.6", @"7.0.5", @"7.0.4", @"7.0.3", @"7.0.2", @"7.0.1", @"7.0", @"6.1", @"6.0", nil];
+	return [NSArray arrayWithObjects:@"8.1", @"8.0", @"7.1.1", @"7.1", @"7.0.6", @"7.0.5", @"7.0.4", @"7.0.3", @"7.0.2", @"7.0.1", @"7.0", @"6.1", @"6.0", nil];
 }
 
 -(NSString*) appPath { return [DEFAULTS stringForKey:APPIUM_PLIST_IOS_APP_PATH]; }

--- a/Appium/Supporting Files/defaults.plist
+++ b/Appium/Supporting Files/defaults.plist
@@ -141,7 +141,7 @@
 	<key>iOS Custom Trace Template Path</key>
 	<string></string>
 	<key>iOS Device Name</key>
-	<string>iPhone</string>
+	<string>iPhone 6</string>
 	<key>iOS Full Reset</key>
 	<false/>
 	<key>iOS Isolate Sim Device</key>
@@ -161,7 +161,7 @@
 	<key>iOS Orientation</key>
 	<string></string>
 	<key>iOS Platform Version</key>
-	<string>7.1</string>
+	<string>8.1</string>
 	<key>iOS Show Simulator Log</key>
 	<true/>
 	<key>iOS Trace Directory</key>


### PR DESCRIPTION
@penguinho, please could you merge if you agree with the below defaults:
- Platform Version: `8.1` (was `7.1`)
- Force Device: `iPhone 6` (was `iPhone` which isn't a valid option on 8.1)
