### PR TITLE
Fix #409 (Incorrect inspection of controls (offset))

### DIFF
--- a/Appium/Inspector/AppiumInspectorWindowController.m
+++ b/Appium/Inspector/AppiumInspectorWindowController.m
@@ -109,6 +109,10 @@
 	{
 		[self.selectedElementHighlightView setHidden:YES];
 	}
+	
+	// Hide selected points, as when the window resizes, they will likely be out of place
+	self.screenshotImageView.beginPoint = nil;
+	self.screenshotImageView.endPoint   = nil;
 }
 
 -(void) awakeFromNib


### PR DESCRIPTION
Fixed an issue introduced with the resizable Inspector window. The selection (clicking on the image) and the highlight display is updated.

@penguinho, please could you take a look before merging, as I have spent all afternoon looking at this and I might have missed something?

Tested against iPhone 6 and iPhone 6 Plus simulators. Also tested with the window widely stretched and widely compressed (to cause large horizontal and large vertical margins).

**There is an ongoing issue with the Inspector selection, but, I have a fix!** I wanted to check before committing. Essentially, when I have been using iOS 8, I noticed that there is a `UIAWindow` that covers the entire screen. This gets selected rather than the elements. The fix I devised was to disable selecting this element, but I wasn't sure if there ever would be a case where a user would need to select this. The below screenshot shows the window at the top of the middle column (it is empty).

![screen shot 2015-02-22 at 20 51 25](https://cloud.githubusercontent.com/assets/1623997/6320417/9b190e2c-bad4-11e4-876c-ec368b70ddf1.png)