### PR TITLE
Fix #541 (Appium 1.5.2 Inspector doesn't respect default command timeout)

### DIFF
--- a/Appium/Inspector/AppiumInspectorWindowController.m
+++ b/Appium/Inspector/AppiumInspectorWindowController.m
@@ -50,9 +50,17 @@
         {
 			// create a new session if one does not already exist
 			SECapabilities *capabilities = [SECapabilities new];
+			
             [capabilities addCapabilityForKey:@"automationName" andValue:(model.isAndroid ? model.android.automationName : @"Appium")];
             [capabilities addCapabilityForKey:@"platformName" andValue:(model.isAndroid ? model.android.platformName : @"iOS")];
 			[capabilities addCapabilityForKey:@"platformVersion" andValue:model.isAndroid ? model.android.platformVersionNumber : model.iOS.platformVersion];
+			
+			if (model.general.commandTimeout && model.general.useCommandTimeout)
+			{
+				[capabilities addCapabilityForKey:@"newCommandTimeout" andValue:model.general.commandTimeout.stringValue];
+			}
+			
+			// Android capabilities
 			if ((model.isAndroid && model.android.useDeviceName) || (model.isIOS && !model.iOS.useDefaultDevice)) {
 				[capabilities addCapabilityForKey:@"deviceName" andValue:model.isAndroid ? model.android.deviceName : model.iOS.deviceName];
 			}
@@ -68,8 +76,8 @@
 			if ((model.isAndroid && model.android.useLocale) || (model.isIOS && model.iOS.useLocale)) {
 				[capabilities addCapabilityForKey:@"locale" andValue:model.isAndroid ? model.android.locale : model.iOS.locale];
 			}
-
-			// iOS caps
+			
+			// iOS capabilities
 			if ((model.isIOS && model.iOS.useAppPath)) {
 				[capabilities addCapabilityForKey:@"app" andValue:model.iOS.appPath];
 			}
@@ -79,7 +87,7 @@
 			if ((model.isIOS && model.iOS.useUDID)) {
 				[capabilities addCapabilityForKey:@"udid" andValue:model.iOS.udid];
 			}
-
+			
             [self.driver startSessionWithDesiredCapabilities:capabilities requiredCapabilities:nil];
 			if (self.driver == nil || self.driver.session == nil || self.driver.session.sessionId == nil)
 			{

--- a/Appium/Model/AppiumModel.m
+++ b/Appium/Model/AppiumModel.m
@@ -172,12 +172,6 @@ BOOL _isServerListening;
 														  withValue:[AppiumServerArgument parseIntegerValue:self.general.callbackPort]]];
 	}
 	
-	if (self.general.useCommandTimeout)
-	{
-		[arguments addObject:[AppiumServerArgument argumentWithName:@"--command-timeout"
-														  withValue:[AppiumServerArgument parseIntegerValue:self.general.commandTimeout]]];
-	}
-	
     if (self.general.overrideExistingSessions)
 	{
 		[arguments addObject:[AppiumServerArgument argumentWithName:@"--session-override"]];


### PR DESCRIPTION
Replaced the deprecated `--command-timeout` with the `newCommandTimeout` capability. This will only fix the Inspector. For external tests, the capability will need to be specified.