### PR TITLE
Fixed #503 and #536 (Appium quits unexpectedly)

### DIFF
--- a/Appium/Inspector/WebDriverElementNode.m
+++ b/Appium/Inspector/WebDriverElementNode.m
@@ -35,7 +35,7 @@
         _showInvisible = showInvisible;
 		[self setParent:parent];
 
-		if ([_jsonDict.allKeys containsObject:@"content-desc"])
+		if ([_jsonDict.allKeys containsObject:@"content-desc"] && [_jsonDict.allKeys containsObject:@"bounds"])
 		{
 			// Android Node
 			[self setPlatform:AppiumAndroidPlatform];


### PR DESCRIPTION
I'm unable to run Android apps on my current setup, so this is a fix based upon the crash logs provided within #503 and #536. I'm not sure if this extra check will create a downside in some other way, but right now if `bounds` is missing from the dictionary, the code within this if statement will crash.

If someone could please check this with an Android app before merging, it would be appreciated.
